### PR TITLE
improving cit digest

### DIFF
--- a/run_after.sh
+++ b/run_after.sh
@@ -122,7 +122,7 @@ list=\$(find \${latest_dev} -maxdepth 3 -type d -name 'job_output' | xargs -I@ s
 for jl in \$list ; do
   out=\$( echo "\$jl" | sed 's|.*scriptTestOutputs/\(.*\)/job_output.*|\1|g' )
   echo processing \$out
-  genpipes tools log_report --tsv \$out.tsv \$jl
+  genpipes tools log_report --loglevel CRITICAL --tsv \$out.tsv \$jl
 done
 
 echo "########################################################" > digest.log

--- a/run_after.sh
+++ b/run_after.sh
@@ -125,7 +125,10 @@ for jl in \$list ; do
   genpipes tools log_report --tsv \$out.tsv \$jl
 done
 
-cat \${SLURM_SUBMIT_DIR}/log_report.log > digest.log
+echo "########################################################" > digest.log
+grep "job_output" *tsv | grep -v "COMPLETE" >> digest.log
+echo "########################################################" >> digest.log
+cat \${SLURM_SUBMIT_DIR}/log_report.log >> digest.log
 ${SEND_TO_J}
 EOF
   sbatch -A "${RAP_ID:-def-bourqueg}" "$tmp_script"


### PR DESCRIPTION
A couple of updates to make the digest.log file a bit more readable. 

- added the table back in that shows jobs from all pipelines that failed, timed out, or ran out of memory
- setting the log_report output to less verbose to make the digest a bit less cluttered